### PR TITLE
build: add gf 3.12 PGF runtime as a dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,7 @@ dependencies:
   - witherable >= 0.4
   - parserModules
   - unicode-show >= 0.1
+  - gf >= 3.12
   - parallel >= 3.2.2
   - yesod >= 1.6
   - yesod-core >= 1.6 && <1.7

--- a/package.yaml
+++ b/package.yaml
@@ -121,6 +121,7 @@ library:
   - DTS.Prover.Wani.BackwardWithRules
   - DTS.Prover.Wani.Arrowterm
   - DTS.Prover.Wani.Prove
+  - GF.ToDTS
 
 executables:
   lightblue:

--- a/src/GF/ToDTS.hs
+++ b/src/GF/ToDTS.hs
@@ -1,0 +1,35 @@
+{-|
+Copyright   : (c) Koharu Saeki, 2026
+Licence     : All right reserved
+Maintainer  : Koharu Saeki
+Stability   : experimental
+
+Translation from GF abstract syntax trees (@PGF.Expr@) into UDTT pretermes.
+
+The target of the translation is an /underspecified/ preterm, i.e. anaphora
+and presuppositions are left as @Asp@ (the \@ operator) and their resolution
+is delegated to the theorem prover wani.
+-}
+
+module GF.ToDTS (
+  -- * Errors
+  TranslationError(..)
+  -- * Translation
+  , gfToDts
+  ) where
+
+import qualified PGF
+import qualified DTS.UDTTdeBruijn as U
+
+-- | Reasons why an abstract syntax tree cannot be translated.
+data TranslationError =
+  UnsupportedFunction String    -- ^ An RGL abstract function with no interpretation (name/arity)
+  | MalformedTree String        -- ^ A tree which is not an application of an abstract function
+  deriving (Eq, Show)
+
+-- | Translates a GF abstract syntax tree into a UDTT preterm.
+gfToDts :: PGF.Expr -> Either TranslationError U.Preterm
+gfToDts expr = case PGF.unApp expr of
+  Just (fun, args) -> Left $ UnsupportedFunction $
+                        PGF.showCId fun ++ "/" ++ show (length args)
+  Nothing          -> Left $ MalformedTree $ PGF.showExpr [] expr

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,8 @@ extra-deps:
 #  - git: git@github.com:DaisukeBekki/hasktorch-tools.git
 #    commit: 936928cdee27e179a5e3775d146046b107b0eba1
 - classy-prelude-yesod-1.5.0@sha256:8f7e183bdfd6d2ea9674284c4f285294ab086aff60d9be4e5d7d2f3c1a2b05b7,1330
+- git: https://github.com/GrammaticalFramework/gf-core.git
+  commit: 1c086bed25811db1cf71990fb2eeca023e62c060
 
 allow-newer: true
 


### PR DESCRIPTION
## 概要

GF の PGF Haskell ランタイム (gf 3.12.0) を lightblue の依存に追加し、GF 抽象統語木から UDTT preterm への変換関数 `gfToDts` の骨組みを `src/GF/ToDTS.hs` として置いた。

- Hackage の gf は 3.11 までのため、gf-core を commit 指定で extra-deps に追加
- 追加が必要な extra-deps は gf-core のみ（残りは lts-18.28 で解決）
- `gfToDts` は現時点で全構成を `Left (UnsupportedFunction "関数名/引数個数")` として返す。treebank に対するカバレッジ計測の起点として使う
- lightblue 既存コードへの変更はなし（package.yaml への依存・モジュール追加のみ）