### PR TITLE
feat: run FraCaS problems end to end via the gf command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,35 @@ To parse a JSeM file and execute inferences therein, then you can feed it to *li
 $ ./lightblue jp jsem -f <jsemfile>
 ```
 
+To execute an inference of the FraCaS GF treebank, give the number of the problem:
+```
+$ export FRACAS_TREEBANK=<path>/FraCaSBankI.gf
+$ export FRACAS_XML=<path>/fracas.xml
+$ ./lightblue gf --problem 49
+```
+This translates the abstract syntax trees of problem 49 into UDTT pretermes and
+prints, in this order, the sentences of the test suite, the settings of the run,
+their trees, the signature, their semantic representations, the type check query
+and diagram of each sentence, the two proof search queries with their diagrams,
+and finally the predicted and the gold label.  To read the proof diagrams in a
+browser, ```--open``` writes an html file and opens it:
+```
+$ ./lightblue gf --problem 49 --open
+```
+The two files are distributed separately from lightblue:
+[FraCaSBankI.gf](https://github.com/heatherleaf/FraCaS-treebank) holds the trees,
+and `fracas.xml` (Bill MacCartney) holds the sentences and the gold answers.
+Their paths may also be given with ```--treebank``` and ```--answers```.
+
 ### Usage
 The syntax of the lightblue command is as follows:
 ```
 ./lightblue <lang> <lang's local options> <command> <command's local options> <global options>
+```
+The ```gf``` command is the exception: it needs no morphological analyzer and no
+input text, so it takes neither a language nor the global options.
+```
+./lightblue gf <gf's local options>
 ```
 
 |Lang    |                           |
@@ -98,10 +123,11 @@ The syntax of the lightblue command is as follows:
 |```parse```     |Parse Sentences and returns parsing results.                           |
 |```jsem```      |Parse a JSeM file and execute inferences.                              |
 |```numeration```|Shows the list of lexical items prepared for parsing the given sentence|
+|```gf```        |Execute an inference of the FraCaS GF treebank (takes no ```<lang>```).|
 |```version```   |Print the lightblue version.                                           |
 |```stat```      |Print the lightblue statistics.                                        |
 
-Each of ```parse ``` and ```jsem``` commands has a set of local options.
+Each of ```parse ```, ```jsem``` and ```gf``` commands has a set of local options.
 
 |Local Options for ```parse```                     |Default   |Description                                                    |  
 |:-------------------------------------------------|:---------|:--------------------------------------------------------------|
@@ -111,6 +137,21 @@ Each of ```parse ``` and ```jsem``` commands has a set of local options.
 |:-------------------------------------------------|:---------|:-------------------------------------|
 |```--jsemid <text>```                             |```all``` |Skip JSeM data the JSeM ID of which is not equial to this value.           |
 |```--nsample <int>```                             |```-1```  |Specify a number of JSeM data to process (A negative value means all data) |
+
+|Local Options for ```gf```                        |Default   |Description                           |
+|:-------------------------------------------------|:---------|:-------------------------------------|
+|```--problem <int>```                             |          |The number (1 to 346) of the FraCaS problem to run. Required. |
+|```--treebank <filepath>```                       |```$FRACAS_TREEBANK```|Path of ```FraCaSBankI.gf```, which holds the abstract syntax trees. |
+|```--answers <filepath>```                        |```$FRACAS_XML```|Path of ```fracas.xml```, which holds the sentences and the gold answers. |
+|```-s``` or ```--style {text\|html}```            |```text```|Show results in the specified format. ```html``` renders the pretermes and the diagrams in MathML. |
+|```-o``` or ```--output <filepath>```             |          |Write results to &lt;filepath&gt; instead of stdout. |
+|```--open```                                      |          |Write an html file and open it in a browser. Implies ```-s html```, and writes to ```fracas<int>.html``` unless ```-o``` says otherwise. |
+|```-p``` or ```--prover {Wani\|Null}```           |```Wani```|Choose a prover. |
+|```--nproof <int>```                              |```1```   |Show N-best proof diagram for each proof search (A negative value means all diagrams) |
+|```--maxdepth <int>```                            |```5```   |Set the maximum search depth in proof search |
+|```--maxtime <int>```                             |```100000```|Set the maximum search time in proof search |
+|```--noDiagram```                                 |          |If specified, show no type check and proof diagram. |
+|```--verbose```                                   |          |Show type infer/check logs in stderr. |
 
 The global options are common to all commands.
 

--- a/app/lightblueMain.hs
+++ b/app/lightblueMain.hs
@@ -2,9 +2,13 @@
 {-# LANGUAGE OverloadedStrings, RecordWildCards #-}
 
 import Options.Applicative hiding (style) --optparse-applicative
-import Control.Applicative (optional)     --base
-import Control.Monad (forM)               --base
+import Control.Applicative (optional,(<|>)) --base
+import Control.Monad (forM,forM_)         --base
+import Control.Exception (catch,IOException) --base
 import Data.Char (toLower)
+import System.Exit (exitFailure)          --base
+import System.Info (os)                   --base
+import System.Process (callCommand)       --process
 import ListT (toList)                     --list-t
 import qualified Data.Text.Lazy as T      --text
 import qualified Data.Text.Lazy.IO as T   --text
@@ -37,6 +41,7 @@ import qualified Interface.Express.Express as Express
 import qualified JSeM as J
 import qualified JSeM.XML as J
 import qualified DTS.UDTTdeBruijn as UDTT
+import qualified DTS.UDTTwithName as UDTTwN
 import qualified DTS.DTTdeBruijn as DTT
 import qualified DTS.DTTwithName as DTTwN
 import DTS.TypeChecker (typeCheck,typeInfer,nullProver)
@@ -44,6 +49,9 @@ import qualified DTS.QueryTypes as QT
 import qualified DTS.NaturalLanguageInference as NLI
 import qualified JSeM as JSeM                         --jsem
 import qualified ML.Exp.Classification.Bounded as NLP --nlp-tools
+import qualified PGF                                  --gf
+import qualified GF.TreebankLoader as GFTB            --lightblue
+import qualified GF.Inference as GFI                  --lightblue
 
 data Options = Options Lang Command I.Style NLI.ProverName FilePath Int Int Int Int Int Int Bool Bool Bool Bool (Maybe Int) Bool Bool Bool (Maybe ExpressBrowser) (Maybe LexicalPos)
 
@@ -58,6 +66,27 @@ data Command =
     deriving (Show, Eq)
 
 data Lang = JP Juman.MorphAnalyzerName JFilter.FilterName | EN deriving (Show, Eq)
+
+-- | The lightblue command is either an inference over the FraCaS GF treebank,
+-- which needs no morphological analyzer and no input text, or one of the
+-- commands which parse a text in a natural language.
+data Invocation = RunGF GFOptions | RunStandard Options
+
+-- | Local options of the gf command.
+data GFOptions = GFOptions {
+  gfTreebank :: FilePath        -- ^ Path of FraCaSBankI.gf
+  , gfAnswers :: FilePath       -- ^ Path of fracas.xml
+  , gfProblem :: Int            -- ^ The number of the problem to run
+  , gfStyle :: I.Style
+  , gfOutput :: FilePath        -- ^ Where to write, or stdout when empty
+  , gfOpen :: Bool              -- ^ Whether to open the result in a browser
+  , gfProverName :: NLI.ProverName
+  , gfNProof :: Int
+  , gfMaxDepth :: Int
+  , gfMaxTime :: Int
+  , gfNoDiagram :: Bool
+  , gfVerbose :: Bool
+  }
 
 -- | Browser selection for Express mode
 data ExpressBrowser = BrowserDefault | BrowserChrome | BrowserFirefox
@@ -265,6 +294,70 @@ parseOptionParser = Parse
     <> showDefault
     <> value I.TREE )
 
+gfOptionParser :: Parser GFOptions
+gfOptionParser = GFOptions
+  <$> strOption
+    ( long "treebank"
+    <> metavar "FILEPATH"
+    <> value ""
+    <> help "Path of FraCaSBankI.gf (default: the value of $FRACAS_TREEBANK)" )
+  <*> strOption
+    ( long "answers"
+    <> metavar "FILEPATH"
+    <> value ""
+    <> help "Path of fracas.xml (default: the value of $FRACAS_XML)" )
+  <*> option auto
+    ( long "problem"
+    <> metavar "INT"
+    <> help "The number of the FraCaS problem to run" )
+  <*> option auto
+    ( long "style"
+    <> short 's'
+    <> metavar "text|html"
+    <> showDefault
+    <> value I.TEXT
+    <> help "Print results in the specified format" )
+  <*> strOption
+    ( long "output"
+    <> short 'o'
+    <> metavar "FILEPATH"
+    <> value ""
+    <> help "Write results to FILEPATH instead of stdout" )
+  <*> switch
+    ( long "open"
+    <> help "Write an html file and open it in a browser (implies -s html)" )
+  <*> option auto
+    ( long "prover"
+    <> short 'p'
+    <> metavar "Wani|Null"
+    <> showDefault
+    <> value NLI.Wani
+    <> help "Choose prover" )
+  <*> option auto
+    ( long "nproof"
+    <> showDefault
+    <> value 1
+    <> metavar "INT"
+    <> help "Show N-best proof diagram for each proof search" )
+  <*> option auto
+    ( long "maxdepth"
+    <> showDefault
+    <> value 5
+    <> metavar "INT"
+    <> help "Set the maximum search depth in proof search" )
+  <*> option auto
+    ( long "maxtime"
+    <> showDefault
+    <> value 100000
+    <> metavar "INT"
+    <> help "Set the maximum search time in proof search" )
+  <*> switch
+    ( long "noDiagram"
+    <> help "If specified, show no type check and proof diagram" )
+  <*> switch
+    ( long "verbose"
+    <> help "Show logs of type inferer and type checker" )
+
 jsemOptionParser :: Parser Command
 jsemOptionParser = JSeM
   <$> strOption
@@ -287,12 +380,189 @@ jsemOptionParser = JSeM
 
 -- | Main function.  Check README.md for the usage.
 main :: IO ()
-main = customExecParser p opts >>= lightblueMain 
-  where opts = info (helper <*> optionParser)
+main = customExecParser p opts >>= run
+  where opts = info (helper <*> invocationParser)
                  ( fullDesc
-                 <> progDesc "Usage: lightblue LANG COMMAND <local options> <global options>"
+                 <> progDesc "Usage: lightblue LANG COMMAND <local options> <global options>, or lightblue gf <local options>"
                  <> header "lightblue - a CCG parser with DTS (c) Daisuke Bekki and Bekki Laboratory" )
         p = prefs showHelpOnEmpty
+        run (RunGF gfOptions) = gfMain gfOptions
+        run (RunStandard options) = lightblueMain options
+
+invocationParser :: Parser Invocation
+invocationParser =
+  (RunGF <$> subparser
+    (command "gf"
+       (info (helper <*> gfOptionParser)
+             (progDesc "Runs an inference of the FraCaS GF treebank.  Needs no morphological analyzer." ))
+    <> metavar "gf"
+    <> commandGroup "Inference over the FraCaS GF treebank"))
+  <|> (RunStandard <$> optionParser)
+
+-- | Renders a result of the gf command.  Only text and html are supported,
+-- since the remaining styles have no notation for a proof diagram.
+gfPrinter :: (T.SimpleText a, I.MathML a) => I.Style -> a -> T.Text
+gfPrinter I.HTML obj = T.concat [I.startMathML, I.toMathML obj, I.endMathML]
+gfPrinter _ obj = T.toText obj
+
+-- | Renders an abstract syntax tree over several lines, so that the structure
+-- can be read off the indentation.  A subtree which fits on one line is kept
+-- on one line, since a leaf on a line of its own only adds noise.
+showTree :: Int -> PGF.Expr -> String
+showTree indent expr
+  | length flat <= 64 = flat
+  | otherwise = case PGF.unApp expr of
+      Just (fun, args@(_:_)) ->
+        "(" ++ PGF.showCId fun
+            ++ concatMap (\arg -> "\n" ++ pad ++ showTree (indent+2) arg) args ++ ")"
+      _ -> flat
+  where
+    -- | An application needs the parentheses which showExpr omits at the top.
+    flat = case PGF.unApp expr of
+             Just (_, []) -> PGF.showExpr [] expr
+             _ -> "(" ++ PGF.showExpr [] expr ++ ")"
+    pad = replicate (indent+2) ' '
+
+-- | Escapes the characters which would be markup in an html page.
+escapeHtml :: String -> String
+escapeHtml = concatMap $ \c -> case c of
+  '&' -> "&amp;"
+  '<' -> "&lt;"
+  '>' -> "&gt;"
+  _ -> [c]
+
+-- | Runs one problem of the FraCaS GF treebank.
+gfMain :: GFOptions -> IO ()
+gfMain GFOptions{..} = do
+  treebankPath <- resolvePath "FRACAS_TREEBANK" "--treebank" gfTreebank
+  answersPath <- resolvePath "FRACAS_XML" "--answers" gfAnswers
+  problems <- GFTB.loadFraCaS treebankPath answersPath
+  case L.find ((== gfProblem) . GFTB.problemId) problems of
+    Nothing -> abort $ "No FraCaS problem is numbered " ++ show gfProblem
+    Just problem -> case GFI.translateProblem problem of
+      Left err -> abort $ "Translation failed: " ++ err
+      Right translation -> do
+        -- | The inference runs before anything is written, so that the answer
+        -- can be put at the top where it is read without scrolling.
+        let prover = NLI.getProver gfProverName $ QT.defaultProofSearchSetting {
+              QT.maxDepth = (Just gfMaxDepth),
+              QT.maxTime = (Just gfMaxTime)
+              }
+        verdict <- GFI.infer prover gfNProof gfVerbose translation
+        handle <- if null outputPath
+                    then return S.stdout
+                    else do h <- S.openFile outputPath S.WriteMode
+                            S.hSetEncoding h S.utf8
+                            return h
+        S.hPutStrLn handle $ I.headerOf style
+        section handle $ "[FraCaS " ++ show (GFTB.problemId problem)
+                         ++ ", section " ++ show (GFTB.section problem) ++ "]"
+        -- | The sentences of the test suite, which the treebank does not hold.
+        case GFTB.gold problem of
+          Nothing -> plain handle "(fracas.xml has no entry for this problem)"
+          Just g -> plain handle $ L.intercalate "\n" $
+            [ "Premise " ++ show i ++ ": " ++ StrictT.unpack text
+            | (text,i) <- zip (GFTB.premiseTexts g) [(1::Int)..] ]
+            ++ [ "Hypothesis: " ++ maybe "(none)" StrictT.unpack
+                                     (GFTB.hypothesisText g) ]
+        section handle "[Result]"
+        plain handle $ L.intercalate "\n"
+          [ "Prediction: " ++ case verdict of
+              GFI.Felicitous result -> show (GFI.answer result)
+              GFI.Infelicitous name -> "(the felicity check of " ++ name ++ " failed)"
+          , "Gold: " ++ maybe "(none)" show (GFTB.answer problem) ]
+        section handle "[Settings]"
+        plain handle $ L.intercalate "\n"
+          [ "prover: " ++ show gfProverName
+          , "nproof: " ++ show gfNProof
+          , "maxdepth: " ++ show gfMaxDepth
+          , "maxtime: " ++ show gfMaxTime
+          , "treebank: " ++ treebankPath
+          , "answers: " ++ answersPath ]
+        section handle "[Abstract syntax trees]"
+        forM_ (GFI.sentences translation) $ \sentence ->
+          plain handle $ GFI.role sentence ++ ":\n  "
+                       ++ showTree 2 (GFI.tree sentence)
+        section handle "[Signature]"
+        T.hPutStrLn handle $ gfPrinter style $ DTTwN.fromDeBruijnSignature
+                           $ GFI.signature translation
+        section handle "[Semantic representations]"
+        forM_ (GFI.sentences translation) $ \sentence -> do
+          plain handle $ GFI.role sentence ++ " ="
+          T.hPutStrLn handle $ gfPrinter style $ UDTTwN.fromDeBruijn []
+                             $ GFI.preterm sentence
+        case verdict of
+          -- | The sections above are written even when the check fails, since
+          -- they are what tells which sentence to look at.
+          GFI.Infelicitous name -> do
+            finish handle
+            abort $ "The semantic felicity check of " ++ name ++ " found no diagram."
+          GFI.Felicitous result -> do
+            forM_ (GFI.felicityChecks result) $ \check -> do
+              section handle $ "[Type check query for " ++ GFI.checkedRole check ++ "]"
+              T.hPutStrLn handle $ gfPrinter style $ UDTTwN.fromDeBruijnJudgment
+                                 $ GFI.checkQuery check
+              showDiagram handle ("Type check diagram for " ++ GFI.checkedRole check)
+                          (GFI.checkDiagram check)
+            showQuery handle "Positive" $ GFI.positive result
+            showQuery handle "Negative" $ GFI.negative result
+            finish handle
+  where
+    -- | An explicit path wins; otherwise --open needs one, and picks its own.
+    outputPath | not (null gfOutput) = gfOutput
+               | gfOpen = "fracas" ++ show gfProblem ++ ".html"
+               | otherwise = ""
+    -- | Opening a page in a browser only makes sense for the html style.
+    style = if gfOpen then I.HTML else gfStyle
+    finish handle =
+      if null outputPath
+        then return ()
+        else do S.hClose handle
+                S.hPutStrLn S.stderr $ "Wrote " ++ outputPath
+                if gfOpen then openInBrowser outputPath else return ()
+    -- | interimOf draws a rule but drops the heading in html, so the heading
+    -- is written out separately, or the sections would carry no label at all.
+    section handle heading = S.hPutStrLn handle $ case style of
+      I.HTML -> I.interimOf style heading ++ "<h3>" ++ escapeHtml heading ++ "</h3>"
+      _ -> I.interimOf style heading
+    -- | Writes plain text, which an html page has to keep the line breaks of.
+    plain handle text = S.hPutStrLn handle $ case style of
+                          I.HTML -> "<pre>" ++ escapeHtml text ++ "</pre>"
+                          _ -> text
+    -- | Both queries are shown even when no proof is found, since an empty
+    -- result is what tells Unknown apart from Yes and No.
+    showQuery handle name (query, diagrams) = do
+      section handle $ "[" ++ name ++ " proof search query]"
+      T.hPutStrLn handle $ gfPrinter style $ DTTwN.fromDeBruijnProofSearchQuery query
+      plain handle $ show (length diagrams) ++ " proof diagram(s) found"
+      forM_ (zip diagrams [(1::Int)..]) $ \(diagram,i) ->
+        showDiagram handle (name ++ " proof diagram " ++ show i) diagram
+    showDiagram handle heading diagram =
+      if gfNoDiagram
+        then return ()
+        else do section handle $ "[" ++ heading ++ "]"
+                T.hPutStrLn handle $ gfPrinter style
+                                   $ fmap DTTwN.fromDeBruijnJudgment diagram
+    abort message = S.hPutStrLn S.stderr message >> exitFailure
+    -- | Falls back on an environment variable when the option is not given.
+    resolvePath envName optName given
+      | not (null given) = return given
+      | otherwise = do
+          fromEnv <- E.lookupEnv envName
+          case fromEnv of
+            Just path | not (null path) -> return path
+            _ -> abort $ "Specify " ++ optName ++ " or set the $" ++ envName
+                         ++ " environment variable."
+
+-- | Hands a file to the browser of the platform.  A failure to open one is not
+-- an error, since the file itself has been written by then.
+openInBrowser :: FilePath -> IO ()
+openInBrowser path = callCommand cmd `catch` \e ->
+    S.hPutStrLn S.stderr $ "Failed to open a browser: " ++ show (e::IOException)
+  where cmd = case os of
+                "darwin" -> "open " ++ show path
+                "mingw32" -> "start " ++ show path
+                _ -> "xdg-open " ++ show path
 
 lightblueMain :: Options -> IO ()
 lightblueMain (Options lang commands style proverName filepath beamW nParse nTypeCheck nProof maxDepth maxTime noTypeCheck noInference ifTime verbose mDepth noShowCat noShowSem leafVertical mExpressBrowser mLexPos) = do

--- a/package.yaml
+++ b/package.yaml
@@ -122,6 +122,7 @@ library:
   - DTS.Prover.Wani.Arrowterm
   - DTS.Prover.Wani.Prove
   - GF.ToDTS
+  - GF.TreebankLoader
 
 executables:
   lightblue:

--- a/package.yaml
+++ b/package.yaml
@@ -123,6 +123,7 @@ library:
   - DTS.Prover.Wani.Prove
   - GF.ToDTS
   - GF.TreebankLoader
+  - GF.Inference
 
 executables:
   lightblue:

--- a/src/GF/Inference.hs
+++ b/src/GF/Inference.hs
@@ -1,0 +1,135 @@
+{-|
+Copyright   : (c) Koharu Saeki, 2026
+Licence     : All right reserved
+Maintainer  : Koharu Saeki
+Stability   : experimental
+
+Inference over the FraCaS GF treebank.  The abstract syntax trees of a problem
+are translated into UDTT pretermes, the semantic felicity of each sentence is
+checked, and the DTT context which the checks build is handed to a prover as a
+proof search query.
+-}
+
+module GF.Inference (
+  -- * Translation
+  Sentence(..)
+  , Translation(..)
+  , translateProblem
+  -- * Inference
+  , Verdict(..)
+  , Result(..)
+  , FelicityCheck(..)
+  , infer
+  ) where
+
+import qualified ListT                    --list-t
+import qualified PGF                      --gf
+import qualified DTS.UDTTdeBruijn as U    --lightblue
+import qualified DTS.DTTdeBruijn as DTT   --lightblue
+import qualified DTS.QueryTypes as QT     --lightblue
+import qualified DTS.TypeChecker as TY    --lightblue
+import qualified Interface.Tree as Tree   --lightblue
+import qualified GF.ToDTS as ToDTS        --lightblue
+import qualified GF.TreebankLoader as TB  --lightblue
+
+-- | A sentence of a problem, with the representations the translation gives it.
+data Sentence = Sentence {
+  role :: String          -- ^ @Premise n@ or @Hypothesis@
+  , tree :: PGF.Expr      -- ^ The abstract syntax tree of the treebank
+  , preterm :: U.Preterm  -- ^ Its UDTT semantic representation
+  }
+
+-- | The translation of a whole problem.
+data Translation = Translation {
+  signature :: DTT.Signature  -- ^ The constants which the sentences introduce
+  , sentences :: [Sentence]   -- ^ The premises, followed by the hypothesis
+  }
+
+-- | Translates the premises and the hypothesis of a problem.  The question is
+-- left out, since it states the proposition the hypothesis states.
+translateProblem :: TB.Problem -> Either String Translation
+translateProblem problem = do
+  hypo <- maybe (Left "the problem has no hypothesis") Right $ TB.hypothesis problem
+  let trees = TB.premises problem ++ [hypo]
+      roles = [ "Premise " ++ show i
+              | i <- [(1::Int) .. length (TB.premises problem)] ] ++ ["Hypothesis"]
+  preterms <- mapM translate trees
+  return Translation { signature = ToDTS.signatureOf trees
+                     , sentences = zipWith3 Sentence roles trees preterms }
+  where
+    translate expr = case ToDTS.gfToDts expr of
+                       Right preterm' -> Right preterm'
+                       Left err -> Left $ show err ++ " in " ++ PGF.showExpr [] expr
+
+-- | The outcome of running a problem.
+data Verdict =
+  Infelicitous String  -- ^ The named sentence yielded no type check diagram.
+  | Felicitous Result
+
+-- | The semantic felicity check of one sentence.
+data FelicityCheck = FelicityCheck {
+  checkedRole :: String            -- ^ The role of the sentence checked
+  , checkQuery :: U.TypeCheckQuery -- ^ The judgment built before the check
+  , checkDiagram :: QT.DTTProofDiagram
+  }
+
+-- | Every query and diagram the inference builds, so that a caller can show them.
+data Result = Result {
+  answer :: TB.Answer
+  -- ^ 'TB.Yes' if the premises prove the hypothesis, 'TB.No' if they refute it.
+  , contxt :: DTT.Context
+  -- ^ The context the felicity checks built.  Its head is the hypothesis and
+  -- its tail is the premises, as in
+  -- 'DTS.NaturalLanguageInference.sequentialTypeCheck'.
+  , felicityChecks :: [FelicityCheck]
+  -- ^ One per sentence, in the order the sentences are given.
+  , positive :: (DTT.ProofSearchQuery, [QT.DTTProofDiagram])
+  -- ^ The query which asks for the hypothesis, and the proofs found.
+  , negative :: (DTT.ProofSearchQuery, [QT.DTTProofDiagram])
+  -- ^ The query which asks for its negation, and the proofs found.
+  }
+
+-- | Checks the semantic felicity of each sentence in turn, and then asks the
+-- prover whether the premises prove the hypothesis, and whether they refute it.
+infer :: QT.Prover
+         -> Int   -- ^ How many proof diagrams to keep (a negative value: all)
+         -> Bool  -- ^ Whether to log the type checking
+         -> Translation
+         -> IO Verdict
+infer prover nProof verbose translation = do
+    checked <- felicityCheck [] (sentences translation)
+    case checked of
+      Left name -> return $ Infelicitous name
+      Right checks -> case contextOf checks of
+        [] -> return $ Infelicitous "(no sentence)"
+        terms@(hypo:prems) -> do
+          let psqPos = DTT.ProofSearchQuery sig prems hypo
+              psqNeg = DTT.ProofSearchQuery sig prems $ DTT.Pi hypo DTT.Bot
+          proofs <- takeNbest $ prover psqPos
+          refutations <- takeNbest $ prover psqNeg
+          return $ Felicitous Result {
+              answer = answerOf proofs refutations
+            , contxt = terms
+            , felicityChecks = reverse checks
+            , positive = (psqPos, proofs)
+            , negative = (psqNeg, refutations)
+            }
+  where
+    sig = signature translation
+    takeNbest = ListT.toList . (if nProof >= 0 then ListT.take nProof else id)
+    -- | The checks are accumulated in reverse, which is the order a context
+    -- takes: the sentence checked last comes first.
+    contextOf = map (DTT.trm . Tree.node . checkDiagram)
+    answerOf proofs refutations
+      | not (null proofs) = TB.Yes
+      | not (null refutations) = TB.No
+      | otherwise = TB.Unknown
+    -- | Extends the context with the first type check diagram of each sentence.
+    felicityCheck checks [] = return $ Right checks
+    felicityCheck checks (sentence:rest) = do
+      let query = U.Judgment sig (contextOf checks) (preterm sentence) DTT.Type
+      diagrams <- ListT.uncons $ TY.typeCheck prover verbose query
+      case diagrams of
+        Nothing -> return $ Left $ role sentence
+        Just (diagram, _) ->
+          felicityCheck (FelicityCheck (role sentence) query diagram : checks) rest

--- a/src/GF/ToDTS.hs
+++ b/src/GF/ToDTS.hs
@@ -57,12 +57,13 @@ translate expr = case PGF.unApp expr of
 
 -- | The interpretation of an abstract function, if the fragment covers it.
 interpret :: PGF.CId -> Maybe U.Preterm
-interpret cid = case M.lookup name structural of
-  Just meaning -> Just $ UwN.toDeBruijn [] meaning
-  Nothing -> lexical name
-  where name = PGF.showCId cid
+interpret cid = case M.lookup name structural of -- structural を引く
+  Just meaning -> Just $ UwN.toDeBruijn [] meaning -- 当たれば de Bruijn に変換して返す
+  Nothing -> lexical name -- 外れれば lexical に回す
+  where name = PGF.showCId cid -- PGF.CId を showCId で String にする("DetCN")
 
 -- | The interpretation of the structural functions of the grammar.
+-- | Todo: データセットで使われている関数に対応する
 structural :: M.Map String UwN.Preterm
 structural = M.fromList [
   -- phrases and clauses
@@ -91,9 +92,8 @@ structural = M.fromList [
   , ("Present", UwN.Unit)
   ]
 
--- | The signature of the constants which the translation of the given trees
--- introduces.  The arity of a content word is read off its category tag, so
--- that a two place verb such as @win_V2@ is given the type
+-- | The signature of the constants which the translation of the given trees introduces.
+-- | The arity of a content word is read off its category tag, so that a two place verb such as @win_V2@ is given the type
 -- @entity -> entity -> type@.
 signatureOf :: [PGF.Expr] -> DTT.Signature
 signatureOf exprs = M.toList $ M.fromList
@@ -118,8 +118,7 @@ splitTag name = case break (== '_') (reverse name) of
   (revTag, '_':revStem) -> Just (reverse revStem, reverse revTag)
   _ -> Nothing
 
--- | Content words are interpreted as constants of the same name.  Function
--- words are excluded, since they call for an interpretation of their own.
+-- | Content words are interpreted as constants of the same name.  Function words are excluded, since they call for an interpretation of their own.
 lexical :: String -> Maybe U.Preterm
 lexical name = case splitTag name of
   Just (stem, tag) | tag `elem` contentTags -> Just $ U.Con $ T.pack stem

--- a/src/GF/ToDTS.hs
+++ b/src/GF/ToDTS.hs
@@ -6,9 +6,32 @@ Stability   : experimental
 
 Translation from GF abstract syntax trees (@PGF.Expr@) into UDTT pretermes.
 
+Every abstract function of the GF grammar is interpreted as a closed UDTT
+preterm, and the application of a function to its arguments is interpreted as
+the application of the pretermes.  The translation of a tree is therefore the
+homomorphic extension of the interpretation of the functions, which is beta
+reduced at the end.
+
 The target of the translation is an /underspecified/ preterm, i.e. anaphora
 and presuppositions are left as @Asp@ (the \@ operator) and their resolution
 is delegated to the theorem prover wani.
+
+The interpretation of the categories is as follows.
+
+@
+  N, CN, A, VP, RCl, RS   Entity -> type
+  NP                      (Entity -> type) -> type
+  Det, Quant              (Entity -> type) -> (Entity -> type) -> type
+  Ord                     (Entity -> type) -> (Entity -> type)
+  V2                      Entity -> Entity -> type
+  VPSlash                 ((Entity -> type) -> type) -> Entity -> type
+  Comp                    Entity -> type
+  Cl, S, Phr              type
+  Num, Pol, Temp, RP      ignored
+@
+
+The fragment currently covers the abstract functions of FraCaS problems 001
+and 049.
 -}
 
 module GF.ToDTS (
@@ -16,10 +39,17 @@ module GF.ToDTS (
   TranslationError(..)
   -- * Translation
   , gfToDts
+  , interpret
+  -- * Signature
+  , signatureOf
   ) where
 
+import qualified Data.Map as M
+import qualified Data.Text.Lazy as T
 import qualified PGF
 import qualified DTS.UDTTdeBruijn as U
+import qualified DTS.UDTTwithName as UwN
+import qualified DTS.DTTdeBruijn as DTT
 
 -- | Reasons why an abstract syntax tree cannot be translated.
 data TranslationError =
@@ -29,7 +59,138 @@ data TranslationError =
 
 -- | Translates a GF abstract syntax tree into a UDTT preterm.
 gfToDts :: PGF.Expr -> Either TranslationError U.Preterm
-gfToDts expr = case PGF.unApp expr of
-  Just (fun, args) -> Left $ UnsupportedFunction $
-                        PGF.showCId fun ++ "/" ++ show (length args)
-  Nothing          -> Left $ MalformedTree $ PGF.showExpr [] expr
+gfToDts expr = U.betaReduce <$> translate expr
+
+translate :: PGF.Expr -> Either TranslationError U.Preterm
+translate expr = case PGF.unApp expr of
+  Nothing -> Left $ MalformedTree $ PGF.showExpr [] expr
+  Just (fun, args) -> case interpret fun of
+    Nothing -> Left $ UnsupportedFunction $
+                 PGF.showCId fun ++ "/" ++ show (length args)
+    Just meaning -> foldl U.App meaning <$> mapM translate args
+
+-- | The interpretation of an abstract function, if the fragment covers it.
+interpret :: PGF.CId -> Maybe U.Preterm
+interpret cid = case M.lookup name structural of
+  Just meaning -> Just $ UwN.toDeBruijn [] meaning
+  Nothing -> lexical name
+  where name = PGF.showCId cid
+
+-- | The interpretation of the structural functions of the grammar.
+structural :: M.Map String UwN.Preterm
+structural = M.fromList [
+  -- phrases and clauses
+  ("Sentence", lam s (var s))                                    -- S -> Phr
+  , ("UseCl", lam t $ lam pl $ lam c $ var c)                    -- Temp -> Pol -> Cl -> S
+  , ("PredVP", lam np $ lam vp $ app (var np) (var vp))          -- NP -> VP -> Cl
+  , ("ExistNP", lam np $ app (var np) (lam x UwN.Top))           -- NP -> Cl
+  -- noun phrases
+  , ("UseN", lam p $ var p)                                      -- N -> CN
+  , ("DetCN", lam d $ lam p $ app (var d) (var p))               -- Det -> CN -> NP
+  , ("DetQuant", lam q $ lam n $ var q)                          -- Quant -> Num -> Det
+  , ("DetQuantOrd", lam q $ lam n $ lam o $ lam p $              -- Quant -> Num -> Ord -> Det
+      app (var q) (app (var o) (var p)))
+  -- quantifiers.  The definite article introduces an @ operator, whose
+  -- resolution is left to the prover.
+  , ("IndefArt", lam p $ lam q $                                 -- Quant
+      UwN.Sigma x UwN.Entity (UwN.Sigma u (app (var p) (var x)) (app (var q) (var x))))
+  , ("DefArt", lam p $ lam q $                                   -- Quant
+      app (var q) (definite (var p)))
+  , ("GenNP", lam np $ lam p $ lam q $                           -- NP -> Quant
+      app (var np) (lam y (app (var q)
+        (definite (lam x (UwN.Sigma u (app (var p) (var x))
+                                      (app (app (UwN.Con "of") (var y)) (var x))))))))
+  , ("OrdSuperl", lam a $ lam p $ lam x $                        -- A -> Ord
+      UwN.Sigma u (app (var p) (var x)) (app (var a) (var x)))
+  , ("every_Det", lam p $ lam q $                                -- Det
+      UwN.Pi x UwN.Entity (UwN.Pi u (app (var p) (var x)) (app (var q) (var x))))
+  -- verb phrases
+  , ("UseComp", lam co $ var co)                                 -- Comp -> VP
+  , ("CompCN", lam p $ var p)                                    -- CN -> Comp
+  , ("SlashV2a", lam v $ lam np $ lam x $                        -- V2 -> VPSlash
+      app (var np) (lam y (app (app (var v) (var y)) (var x))))
+  , ("ComplSlash", lam vs $ lam np $ app (var vs) (var np))      -- VPSlash -> NP -> VP
+  -- relative clauses
+  , ("UseRCl", lam t $ lam pl $ lam r $ var r)                   -- Temp -> Pol -> RCl -> RS
+  , ("RelVP", lam rp $ lam vp $ var vp)                          -- RP -> VP -> RCl
+  , ("RelCN", lam p $ lam r $ lam x $                            -- CN -> RS -> CN
+      UwN.Sigma u (app (var p) (var x)) (app (var r) (var x)))
+  -- the fragment ignores number, polarity, tense and the relative pronoun
+  , ("NumSg", UwN.Unit)
+  , ("NumPl", UwN.Unit)
+  , ("PPos", UwN.Unit)
+  , ("Past", UwN.Unit)
+  , ("Present", UwN.Unit)
+  , ("IdRP", UwN.Unit)
+  ]
+
+-- | @definite p@ is the first projection of an underspecified term of the
+-- type of the entities which satisfy @p@, i.e. the DTS treatment of a
+-- presupposition triggered by a definite noun phrase.
+definite :: UwN.Preterm -> UwN.Preterm
+definite p = UwN.Proj UwN.Fst (UwN.Asp (UwN.Sigma x UwN.Entity (app p (var x))))
+
+-- | The signature of the constants which the translation of the given trees
+-- introduces.  The arity of a content word is read off its category tag, so
+-- that a two place verb such as @win_V2@ is given the type
+-- @entity -> entity -> type@.
+signatureOf :: [PGF.Expr] -> DTT.Signature
+signatureOf exprs = M.toList $ M.fromList
+  [ (T.pack stem, nPlacePred arity)
+  | name <- concatMap names exprs
+  , (stem, tag) <- maybe [] (:[]) (splitTag name)
+  , arity <- maybe [] (:[]) (lookup tag arities) ]
+  where
+    names expr = case PGF.unApp expr of
+                   Just (fun, args) -> PGF.showCId fun : concatMap names args
+                   Nothing -> []
+    arities = [("N", 1), ("A", 1), ("V", 1), ("Adv", 1)
+              ,("N2", 2), ("A2", 2), ("V2", 2), ("V3", 3), ("PN", 0)]
+    nPlacePred k = iterate (DTT.Pi DTT.Entity) DTT.Type !! k
+
+-- | Splits @win_V2@ into the stem and the category tag.
+splitTag :: String -> Maybe (String, String)
+splitTag name = case break (== '_') (reverse name) of
+  (revTag, '_':revStem) -> Just (reverse revStem, reverse revTag)
+  _ -> Nothing
+
+-- | Content words are interpreted as constants of the same name.  Function
+-- words are excluded, since they call for an interpretation of their own.
+lexical :: String -> Maybe U.Preterm
+lexical name = case splitTag name of
+  Just (stem, tag) | tag `elem` contentTags -> Just $ U.Con $ T.pack stem
+  _ -> Nothing
+  where contentTags = ["N", "N2", "A", "A2", "V", "V2", "V3", "PN", "Adv"]
+
+-- variable names, kept distinct within each interpretation
+
+a, c, co, d, n, np, o, p, pl, q, r, rp, s, t, u, v, vp, vs, x, y :: UwN.VarName
+a = UwN.VarName 'a' 0
+c = UwN.VarName 'c' 0
+co = UwN.VarName 'C' 0
+d = UwN.VarName 'd' 0
+n = UwN.VarName 'n' 0
+np = UwN.VarName 'N' 0
+o = UwN.VarName 'o' 0
+p = UwN.VarName 'p' 0
+pl = UwN.VarName 'l' 0
+q = UwN.VarName 'q' 0
+r = UwN.VarName 'r' 0
+rp = UwN.VarName 'R' 0
+s = UwN.VarName 's' 0
+t = UwN.VarName 't' 0
+u = UwN.VarName 'u' 0
+v = UwN.VarName 'v' 0
+vp = UwN.VarName 'V' 0
+vs = UwN.VarName 'S' 0
+x = UwN.VarName 'x' 0
+y = UwN.VarName 'y' 0
+
+lam :: UwN.VarName -> UwN.Preterm -> UwN.Preterm
+lam = UwN.Lam
+
+var :: UwN.VarName -> UwN.Preterm
+var = UwN.Var
+
+app :: UwN.Preterm -> UwN.Preterm -> UwN.Preterm
+app = UwN.App

--- a/src/GF/ToDTS.hs
+++ b/src/GF/ToDTS.hs
@@ -7,6 +7,7 @@ Stability   : experimental
 Translation from GF abstract syntax trees (@PGF.Expr@) into UDTT pretermes.
 
 @
+  PN                      Entity
   N, CN, VP, Comp         Entity -> type
   NP                      (Entity -> type) -> type
   Det, Quant              (Entity -> type) -> (Entity -> type) -> type
@@ -71,6 +72,7 @@ structural = M.fromList [
   -- noun phrases
   , ("UseN", lam p $ var p)                                      -- N -> CN
   , ("DetCN", lam d $ lam p $ app (var d) (var p))               -- Det -> CN -> NP
+  , ("UsePN", lam x $ lam p $ app (var p) (var x))               -- PN -> NP
   , ("DetQuant", lam q $ lam n $ var q)                          -- Quant -> Num -> Det
   , ("IndefArt", lam p $ lam q $                                 -- Quant
       UwN.Sigma x UwN.Entity (UwN.Sigma u (app (var p) (var x)) (app (var q) (var x))))
@@ -95,16 +97,19 @@ structural = M.fromList [
 -- @entity -> entity -> type@.
 signatureOf :: [PGF.Expr] -> DTT.Signature
 signatureOf exprs = M.toList $ M.fromList
-  [ (T.pack stem, nPlacePred arity)
+  [ (T.pack stem, typ)
   | name <- concatMap names exprs
   , (stem, tag) <- maybe [] (:[]) (splitTag name)
-  , arity <- maybe [] (:[]) (lookup tag arities) ]
+  , typ <- maybe [] (:[]) (lookup tag types) ]
   where
     names expr = case PGF.unApp expr of
                    Just (fun, args) -> PGF.showCId fun : concatMap names args
                    Nothing -> []
-    arities = [("N", 1), ("A", 1), ("V", 1), ("Adv", 1)
-              ,("N2", 2), ("A2", 2), ("V2", 2), ("V3", 3), ("PN", 0)]
+    types = [("PN", DTT.Entity)                     -- a proper name denotes an entity
+            ,("N", nPlacePred 1), ("A", nPlacePred 1)
+            ,("V", nPlacePred 1), ("Adv", nPlacePred 1)
+            ,("N2", nPlacePred 2), ("A2", nPlacePred 2), ("V2", nPlacePred 2)
+            ,("V3", nPlacePred 3)]
     nPlacePred k = iterate (DTT.Pi DTT.Entity) DTT.Type !! k
 
 -- | Splits @win_V2@ into the stem and the category tag.

--- a/src/GF/ToDTS.hs
+++ b/src/GF/ToDTS.hs
@@ -6,18 +6,6 @@ Stability   : experimental
 
 Translation from GF abstract syntax trees (@PGF.Expr@) into UDTT pretermes.
 
-Every abstract function of the GF grammar is interpreted as a closed UDTT
-preterm, and the application of a function to its arguments is interpreted as
-the application of the pretermes.  The translation of a tree is therefore the
-homomorphic extension of the interpretation of the functions, which is beta
-reduced at the end.
-
-The target of the translation is an /underspecified/ preterm, i.e. anaphora
-and presuppositions are left as @Asp@ (the \@ operator) and their resolution
-is delegated to the theorem prover wani.
-
-The interpretation of the categories is as follows.
-
 @
   N, CN, A, VP, RCl, RS   Entity -> type
   NP                      (Entity -> type) -> type
@@ -30,8 +18,7 @@ The interpretation of the categories is as follows.
   Num, Pol, Temp, RP      ignored
 @
 
-The fragment currently covers the abstract functions of FraCaS problems 001
-and 049.
+The fragment currently covers the abstract functions of FraCaS problems 001 and 049.
 -}
 
 module GF.ToDTS (

--- a/src/GF/ToDTS.hs
+++ b/src/GF/ToDTS.hs
@@ -7,18 +7,16 @@ Stability   : experimental
 Translation from GF abstract syntax trees (@PGF.Expr@) into UDTT pretermes.
 
 @
-  N, CN, A, VP, RCl, RS   Entity -> type
+  N, CN, VP, Comp         Entity -> type
   NP                      (Entity -> type) -> type
   Det, Quant              (Entity -> type) -> (Entity -> type) -> type
-  Ord                     (Entity -> type) -> (Entity -> type)
   V2                      Entity -> Entity -> type
   VPSlash                 ((Entity -> type) -> type) -> Entity -> type
-  Comp                    Entity -> type
   Cl, S, Phr              type
-  Num, Pol, Temp, RP      ignored
+  Num, Pol, Temp          ignored
 @
 
-The fragment currently covers the abstract functions of FraCaS problems 001 and 049.
+The fragment currently covers the abstract functions of FraCaS problem 049.
 -}
 
 module GF.ToDTS (
@@ -70,25 +68,12 @@ structural = M.fromList [
   ("Sentence", lam s (var s))                                    -- S -> Phr
   , ("UseCl", lam t $ lam pl $ lam c $ var c)                    -- Temp -> Pol -> Cl -> S
   , ("PredVP", lam np $ lam vp $ app (var np) (var vp))          -- NP -> VP -> Cl
-  , ("ExistNP", lam np $ app (var np) (lam x UwN.Top))           -- NP -> Cl
   -- noun phrases
   , ("UseN", lam p $ var p)                                      -- N -> CN
   , ("DetCN", lam d $ lam p $ app (var d) (var p))               -- Det -> CN -> NP
   , ("DetQuant", lam q $ lam n $ var q)                          -- Quant -> Num -> Det
-  , ("DetQuantOrd", lam q $ lam n $ lam o $ lam p $              -- Quant -> Num -> Ord -> Det
-      app (var q) (app (var o) (var p)))
-  -- quantifiers.  The definite article introduces an @ operator, whose
-  -- resolution is left to the prover.
   , ("IndefArt", lam p $ lam q $                                 -- Quant
       UwN.Sigma x UwN.Entity (UwN.Sigma u (app (var p) (var x)) (app (var q) (var x))))
-  , ("DefArt", lam p $ lam q $                                   -- Quant
-      app (var q) (definite (var p)))
-  , ("GenNP", lam np $ lam p $ lam q $                           -- NP -> Quant
-      app (var np) (lam y (app (var q)
-        (definite (lam x (UwN.Sigma u (app (var p) (var x))
-                                      (app (app (UwN.Con "of") (var y)) (var x))))))))
-  , ("OrdSuperl", lam a $ lam p $ lam x $                        -- A -> Ord
-      UwN.Sigma u (app (var p) (var x)) (app (var a) (var x)))
   , ("every_Det", lam p $ lam q $                                -- Det
       UwN.Pi x UwN.Entity (UwN.Pi u (app (var p) (var x)) (app (var q) (var x))))
   -- verb phrases
@@ -97,25 +82,12 @@ structural = M.fromList [
   , ("SlashV2a", lam v $ lam np $ lam x $                        -- V2 -> VPSlash
       app (var np) (lam y (app (app (var v) (var y)) (var x))))
   , ("ComplSlash", lam vs $ lam np $ app (var vs) (var np))      -- VPSlash -> NP -> VP
-  -- relative clauses
-  , ("UseRCl", lam t $ lam pl $ lam r $ var r)                   -- Temp -> Pol -> RCl -> RS
-  , ("RelVP", lam rp $ lam vp $ var vp)                          -- RP -> VP -> RCl
-  , ("RelCN", lam p $ lam r $ lam x $                            -- CN -> RS -> CN
-      UwN.Sigma u (app (var p) (var x)) (app (var r) (var x)))
-  -- the fragment ignores number, polarity, tense and the relative pronoun
+  -- the fragment ignores number, polarity and tense
   , ("NumSg", UwN.Unit)
-  , ("NumPl", UwN.Unit)
   , ("PPos", UwN.Unit)
   , ("Past", UwN.Unit)
   , ("Present", UwN.Unit)
-  , ("IdRP", UwN.Unit)
   ]
-
--- | @definite p@ is the first projection of an underspecified term of the
--- type of the entities which satisfy @p@, i.e. the DTS treatment of a
--- presupposition triggered by a definite noun phrase.
-definite :: UwN.Preterm -> UwN.Preterm
-definite p = UwN.Proj UwN.Fst (UwN.Asp (UwN.Sigma x UwN.Entity (app p (var x))))
 
 -- | The signature of the constants which the translation of the given trees
 -- introduces.  The arity of a content word is read off its category tag, so
@@ -151,19 +123,15 @@ lexical name = case splitTag name of
 
 -- variable names, kept distinct within each interpretation
 
-a, c, co, d, n, np, o, p, pl, q, r, rp, s, t, u, v, vp, vs, x, y :: UwN.VarName
-a = UwN.VarName 'a' 0
+c, co, d, n, np, p, pl, q, s, t, u, v, vp, vs, x, y :: UwN.VarName
 c = UwN.VarName 'c' 0
 co = UwN.VarName 'C' 0
 d = UwN.VarName 'd' 0
 n = UwN.VarName 'n' 0
 np = UwN.VarName 'N' 0
-o = UwN.VarName 'o' 0
 p = UwN.VarName 'p' 0
 pl = UwN.VarName 'l' 0
 q = UwN.VarName 'q' 0
-r = UwN.VarName 'r' 0
-rp = UwN.VarName 'R' 0
 s = UwN.VarName 's' 0
 t = UwN.VarName 't' 0
 u = UwN.VarName 'u' 0

--- a/src/GF/TreebankLoader.hs
+++ b/src/GF/TreebankLoader.hs
@@ -1,0 +1,158 @@
+{-|
+Copyright   : (c) Koharu Saeki, 2026
+Licence     : All right reserved
+Maintainer  : Koharu Saeki
+Stability   : experimental
+
+Loader for the FraCaS GF treebank (Ljunglöf and Siverbo 2011).
+
+The treebank itself is distributed separately under GPL v3, so the files are
+read from paths given by the caller:
+
+* @src\/FraCaSBankI.gf@ of <https://github.com/heatherleaf/FraCaS-treebank>,
+  which holds the language independent abstract syntax trees.
+* @fracas.xml@ of Bill MacCartney, which holds the gold answers.
+-}
+
+module GF.TreebankLoader (
+  -- * Problems
+  Answer(..)
+  , Problem(..)
+  -- * Loading
+  , loadFraCaS
+  , loadTrees
+  , loadAnswers
+  -- * Sections
+  , sectionOf
+  ) where
+
+import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Data.Char (isDigit)
+import Data.List (sortOn)
+import Data.Maybe (mapMaybe)
+import qualified PGF
+import qualified Text.XML as X
+import Text.XML.Cursor (($//), (&|), attribute, element, fromDocument)
+
+-- | The gold answer of a FraCaS problem.  @Undef@ marks the problems whose
+-- answer the FraCaS report itself leaves open.
+data Answer = Yes | No | Unknown | Undef deriving (Eq, Show)
+
+-- | A FraCaS problem, with its sentences given as GF abstract syntax trees.
+-- Four problems have no question, and one has no hypothesis.
+data Problem = Problem {
+  problemId :: Int                -- ^ 1 to 346
+  , section :: Int                -- ^ 1 to 9, see 'sectionOf'
+  , premises :: [PGF.Expr]        -- ^ In the order they appear in the problem
+  , question :: Maybe PGF.Expr
+  , hypothesis :: Maybe PGF.Expr
+  , answer :: Maybe Answer
+  }
+
+-- | Loads the treebank and the gold answers, and pairs them up by problem id.
+loadFraCaS :: FilePath          -- ^ Path of @FraCaSBankI.gf@
+              -> FilePath       -- ^ Path of @fracas.xml@
+              -> IO [Problem]
+loadFraCaS treebankPath xmlPath = do
+  trees <- loadTrees treebankPath
+  answers <- loadAnswers xmlPath
+  return $ assemble trees answers
+
+-- | Reads the abstract syntax trees of @FraCaSBankI.gf@, keyed by the
+-- identifiers of the treebank (e.g. @s_001_2_q@).
+loadTrees :: FilePath -> IO (M.Map T.Text PGF.Expr)
+loadTrees path = do
+  txt <- T.readFile path
+  let lins = M.fromList $ mapMaybe parseLin $ T.lines txt
+  return $ M.mapMaybe (\body -> PGF.readExpr . T.unpack =<< dealias lins body) lins
+
+-- | Reads the @fracas_answer@ attributes of @fracas.xml@.
+loadAnswers :: FilePath -> IO (M.Map Int Answer)
+loadAnswers path = do
+  doc <- X.readFile X.def path
+  let rows = fromDocument doc $// element "problem"
+               &| \c -> (attribute "id" c, attribute "fracas_answer" c)
+  return $ M.fromList [(i, a) | (ids, as) <- rows
+                              , i <- mapMaybe (readInt . T.unpack) ids
+                              , a <- mapMaybe toAnswer as]
+
+-- | The section of the FraCaS test suite a problem belongs to.  The boundaries
+-- are those of the section markers of @fracas.xml@.
+sectionOf :: Int -> Int
+sectionOf i
+  | i < 81 = 1    -- generalized quantifiers
+  | i < 114 = 2   -- plurals
+  | i < 142 = 3   -- (nominal) anaphora
+  | i < 197 = 4   -- ellipsis
+  | i < 220 = 5   -- adjectives
+  | i < 251 = 6   -- comparatives
+  | i < 326 = 7   -- temporal reference
+  | i < 334 = 8   -- verbs
+  | otherwise = 9 -- attitudes
+
+-- | Splits a line of the form @lin \<identifier\> = \<body\>;@.
+parseLin :: T.Text -> Maybe (T.Text, T.Text)
+parseLin line = do
+  rest <- T.stripPrefix "lin " (T.strip line)
+  let (key, body) = T.breakOn "=" rest
+  body' <- T.stripPrefix "=" body
+  return (T.strip key, T.strip (T.dropWhileEnd (== ';') (T.strip body')))
+
+-- | Follows the definitions which are aliases of another entry, such as
+-- @lin s_003_2_p = s_002_2_p;@.  Cyclic definitions yield 'Nothing'.
+dealias :: M.Map T.Text T.Text -> T.Text -> Maybe T.Text
+dealias lins = go (M.size lins)
+  where go :: Int -> T.Text -> Maybe T.Text
+        go n body
+          | n < 0 = Nothing
+          | otherwise = case M.lookup body lins of
+                          Just body' -> go (n - 1) body'
+                          Nothing -> Just body
+
+-- | Collects the trees of each problem.  Identifiers are of the form
+-- @s_\<problem\>_\<index\>_\<role\>@, the role being @p@, @q@ or @h@.
+assemble :: M.Map T.Text PGF.Expr -> M.Map Int Answer -> [Problem]
+assemble trees answers =
+  [ Problem { problemId = i
+            , section = sectionOf i
+            , premises = [e | (_, "p", e) <- entries]
+            , question = listToMaybe' [e | (_, "q", e) <- entries]
+            , hypothesis = listToMaybe' [e | (_, "h", e) <- entries]
+            , answer = M.lookup i answers
+            }
+  | (i, unsorted) <- M.toAscList grouped
+  , let entries = sortOn (\(idx, _, _) -> idx) unsorted ]
+  where
+    grouped = M.fromListWith (++)
+                [(i, [(idx, role, e)]) | (key, e) <- M.toList trees
+                                       , Just (i, idx, role) <- [parseKey key]]
+    listToMaybe' xs = case xs of
+                        (x:_) -> Just x
+                        [] -> Nothing
+
+-- | Splits @s_001_2_q@ into the problem number, the index and the role.
+-- The treebank leaves fourteen sentences unannotated as @variants{}@, six of
+-- which are superseded by an entry with a @_NEW@ suffix.  Only the latter is
+-- readable as a tree, so the two are not in conflict.
+parseKey :: T.Text -> Maybe (Int, Int, T.Text)
+parseKey key = case T.splitOn "_" key of
+  ["s", num, idx, role] -> build num idx role
+  ["s", num, idx, role, "NEW"] -> build num idx role
+  _ -> Nothing
+  where build num idx role = do
+          i <- readInt (T.unpack num)
+          j <- readInt (T.unpack idx)
+          return (i, j, role)
+
+readInt :: String -> Maybe Int
+readInt s = if not (null s) && all isDigit s then Just (read s) else Nothing
+
+toAnswer :: T.Text -> Maybe Answer
+toAnswer a = case a of
+  "yes" -> Just Yes
+  "no" -> Just No
+  "unknown" -> Just Unknown
+  "undef" -> Just Undef
+  _ -> Nothing

--- a/src/GF/TreebankLoader.hs
+++ b/src/GF/TreebankLoader.hs
@@ -17,11 +17,12 @@ read from paths given by the caller:
 module GF.TreebankLoader (
   -- * Problems
   Answer(..)
+  , Gold(..)
   , Problem(..)
   -- * Loading
   , loadFraCaS
   , loadTrees
-  , loadAnswers
+  , loadGold
   -- * Sections
   , sectionOf
   ) where
@@ -34,11 +35,18 @@ import Data.List (sortOn)
 import Data.Maybe (mapMaybe)
 import qualified PGF
 import qualified Text.XML as X
-import Text.XML.Cursor (($//), (&|), attribute, element, fromDocument)
+import Text.XML.Cursor (($//), ($/), (&|), attribute, content, element, fromDocument)
 
 -- | The gold answer of a FraCaS problem.  @Undef@ marks the problems whose
 -- answer the FraCaS report itself leaves open.
 data Answer = Yes | No | Unknown | Undef deriving (Eq, Show)
+
+-- | What @fracas.xml@ records about a problem, besides its trees.
+data Gold = Gold {
+  goldAnswer :: Maybe Answer
+  , premiseTexts :: [T.Text]       -- ^ The premises as the test suite words them
+  , hypothesisText :: Maybe T.Text
+  }
 
 -- | A FraCaS problem, with its sentences given as GF abstract syntax trees.
 -- Four problems have no question, and one has no hypothesis.
@@ -49,6 +57,7 @@ data Problem = Problem {
   , question :: Maybe PGF.Expr
   , hypothesis :: Maybe PGF.Expr
   , answer :: Maybe Answer
+  , gold :: Maybe Gold            -- ^ The entry of @fracas.xml@, if there is one
   }
 
 -- | Loads the treebank and the gold answers, and pairs them up by problem id.
@@ -57,8 +66,8 @@ loadFraCaS :: FilePath          -- ^ Path of @FraCaSBankI.gf@
               -> IO [Problem]
 loadFraCaS treebankPath xmlPath = do
   trees <- loadTrees treebankPath
-  answers <- loadAnswers xmlPath
-  return $ assemble trees answers
+  golds <- loadGold xmlPath
+  return $ assemble trees golds
 
 -- | Reads the abstract syntax trees of @FraCaSBankI.gf@, keyed by the
 -- identifiers of the treebank (e.g. @s_001_2_q@).
@@ -68,15 +77,22 @@ loadTrees path = do
   let lins = M.fromList $ mapMaybe parseLin $ T.lines txt
   return $ M.mapMaybe (\body -> PGF.readExpr . T.unpack =<< dealias lins body) lins
 
--- | Reads the @fracas_answer@ attributes of @fracas.xml@.
-loadAnswers :: FilePath -> IO (M.Map Int Answer)
-loadAnswers path = do
+-- | Reads the gold answers and the sentences of @fracas.xml@.  The sentences
+-- are the ones the test suite words, and are kept for display only: the
+-- translation reads the trees of the treebank instead.
+loadGold :: FilePath -> IO (M.Map Int Gold)
+loadGold path = do
   doc <- X.readFile X.def path
-  let rows = fromDocument doc $// element "problem"
-               &| \c -> (attribute "id" c, attribute "fracas_answer" c)
-  return $ M.fromList [(i, a) | (ids, as) <- rows
-                              , i <- mapMaybe (readInt . T.unpack) ids
-                              , a <- mapMaybe toAnswer as]
+  let rows = fromDocument doc $// element "problem" &| \c ->
+               (attribute "id" c
+               , Gold { goldAnswer = listToMaybe' $ mapMaybe toAnswer
+                                   $ attribute "fracas_answer" c
+                      , premiseTexts = textsOf "p" c
+                      , hypothesisText = listToMaybe' $ textsOf "h" c })
+  return $ M.fromList [(i, g) | (ids, g) <- rows
+                              , i <- mapMaybe (readInt . T.unpack) ids]
+  where textsOf name c = [ T.strip $ T.concat (child $/ content)
+                         | child <- c $/ element name ]
 
 -- | The section of the FraCaS test suite a problem belongs to.  The boundaries
 -- are those of the section markers of @fracas.xml@.
@@ -113,14 +129,15 @@ dealias lins = go (M.size lins)
 
 -- | Collects the trees of each problem.  Identifiers are of the form
 -- @s_\<problem\>_\<index\>_\<role\>@, the role being @p@, @q@ or @h@.
-assemble :: M.Map T.Text PGF.Expr -> M.Map Int Answer -> [Problem]
-assemble trees answers =
+assemble :: M.Map T.Text PGF.Expr -> M.Map Int Gold -> [Problem]
+assemble trees golds =
   [ Problem { problemId = i
             , section = sectionOf i
             , premises = [e | (_, "p", e) <- entries]
             , question = listToMaybe' [e | (_, "q", e) <- entries]
             , hypothesis = listToMaybe' [e | (_, "h", e) <- entries]
-            , answer = M.lookup i answers
+            , answer = goldAnswer =<< M.lookup i golds
+            , gold = M.lookup i golds
             }
   | (i, unsorted) <- M.toAscList grouped
   , let entries = sortOn (\(idx, _, _) -> idx) unsorted ]
@@ -128,9 +145,6 @@ assemble trees answers =
     grouped = M.fromListWith (++)
                 [(i, [(idx, role, e)]) | (key, e) <- M.toList trees
                                        , Just (i, idx, role) <- [parseKey key]]
-    listToMaybe' xs = case xs of
-                        (x:_) -> Just x
-                        [] -> Nothing
 
 -- | Splits @s_001_2_q@ into the problem number, the index and the role.
 -- The treebank leaves fourteen sentences unannotated as @variants{}@, six of
@@ -148,6 +162,11 @@ parseKey key = case T.splitOn "_" key of
 
 readInt :: String -> Maybe Int
 readInt s = if not (null s) && all isDigit s then Just (read s) else Nothing
+
+listToMaybe' :: [a] -> Maybe a
+listToMaybe' xs = case xs of
+                    (x:_) -> Just x
+                    [] -> Nothing
 
 toAnswer :: T.Text -> Maybe Answer
 toAnswer a = case a of


### PR DESCRIPTION
## 目的

FraCaS GF treebank の問題を1問指定して、GF 抽象木 → UDTT 意味表示 → SFC 検査 → wani 証明探索まで一括実行できるようにする(修論パイプラインの最小動作版)。

## 変更内容

- `GF.TreebankLoader`: fracas.xml から自然言語文(前提・仮説)も読む(`Gold` 型)
- `GF.Inference`(新規): 翻訳 → 各文の SFC 検査 → 肯定/否定の証明探索。クエリ・証明図をすべて返す
- `lightblue gf` コマンド(新規): `--problem N` で1問実行。text / MathML html 出力、`--open` でブラウザ表示
- README にコマンドの説明を追加

## 動作確認

- `stack build` エラー0、新規コードに -Wall 警告なし
- 問題49: Prediction Yes / Gold Yes、問題65: Unknown / Unknown
- 未対応問題(例: 1)は `UnsupportedFunction` で停止し誤答しない
- 既存コマンド(`en version` / `en parse`)に回帰なし

## 既存コードへの影響

lightblue 本体(`src/` 既存モジュール)の変更なし。`app/lightblueMain.hs` は `gf` サブコマンドの追加のみで、既存コマンドの経路は不変。
